### PR TITLE
Hide IMCollectionLoadingView on iOS 7 due to issues with masonry.

### DIFF
--- a/Source/CollectionView/IMCollectionLoadingView.h
+++ b/Source/CollectionView/IMCollectionLoadingView.h
@@ -23,6 +23,7 @@
 //  IN THE SOFTWARE.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface IMCollectionLoadingView : UIView

--- a/Source/CollectionView/IMCollectionLoadingView.m
+++ b/Source/CollectionView/IMCollectionLoadingView.m
@@ -26,7 +26,9 @@
 #import "IMCollectionLoadingView.h"
 #import "View+MASAdditions.h"
 
-@implementation IMCollectionLoadingView
+@implementation IMCollectionLoadingView {
+
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];

--- a/Source/CollectionView/IMCollectionView.h
+++ b/Source/CollectionView/IMCollectionView.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSUInteger, IMCollectionViewContentType) {
 
 extern NSUInteger const IMCollectionViewNumberOfItemsToLoad;
 
-@class IMImojiSession, IMImojiCategoryObject, IMImojiObject;
+@class IMImojiSession, IMImojiCategoryObject, IMImojiObject, IMCollectionLoadingView;
 
 @protocol IMCollectionViewDelegate;
 
@@ -87,6 +87,13 @@ extern NSUInteger const IMCollectionViewNumberOfItemsToLoad;
  * @abstract Whether or not infinite scrolling of content is enabled. Defaults to NO.
 */
 @property(nonatomic) BOOL infiniteScroll;
+
+/**
+ * @abstract Indicates that the current view is loading. Only for the initial view.
+ * Subsequent loading views, such as loading the next page of results within a category,
+ * are handled by IMCollectionViewStatusCell.
+ */
+@property(nonatomic, strong, nullable) IMCollectionLoadingView *loadingView;
 
 /**
  * @abstract The default rendering options to use for displaying the stickers. Defaults to

--- a/Source/CollectionView/IMCollectionView.m
+++ b/Source/CollectionView/IMCollectionView.m
@@ -62,7 +62,6 @@ CGFloat const IMCollectionReusableAttributionViewDefaultHeight = 187.0f;
 @property(nonatomic) BOOL shouldLoadNewSection;
 
 @property(nonatomic) NSUInteger renderCount;
-@property(nonatomic, strong) IMCollectionLoadingView *loadingView;
 
 @end
 
@@ -100,14 +99,16 @@ CGFloat const IMCollectionReusableAttributionViewDefaultHeight = 187.0f;
         self.tapGesture.enabled = NO;
         [self addGestureRecognizer:self.tapGesture];
 
-        self.loadingView = [[IMCollectionLoadingView alloc] initWithFrame:CGRectZero];
-        self.loadingView.backgroundColor = [UIColor whiteColor];
+        if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_8_0) {
+            self.loadingView = [[IMCollectionLoadingView alloc] initWithFrame:CGRectZero];
+            self.loadingView.backgroundColor = self.backgroundColor;
 
-        [self addSubview:self.loadingView];
+            [self addSubview:self.loadingView];
 
-        [self.loadingView mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.width.and.height.equalTo(self);
-        }];
+            [self.loadingView mas_makeConstraints:^(MASConstraintMaker *make) {
+                make.width.and.height.equalTo(self);
+            }];
+        }
 
         [self registerClass:[IMCollectionViewCell class] forCellWithReuseIdentifier:IMCollectionViewCellReuseId];
         [self registerClass:[IMCategoryCollectionViewCell class] forCellWithReuseIdentifier:IMCategoryCollectionViewCellReuseId];

--- a/Source/KeyboardView/Source/Views/IMKeyboardView.m
+++ b/Source/KeyboardView/Source/Views/IMKeyboardView.m
@@ -30,6 +30,7 @@
 #import "IMAttributeStringUtil.h"
 #import "IMConnectivityUtil.h"
 #import "IMKeyboardSearchTextField.h"
+#import "IMCollectionLoadingView.h"
 
 NSString *const IMKeyboardViewDefaultFontFamily = @"Imoji-Regular";
 
@@ -128,6 +129,7 @@ NSString *const IMKeyboardViewDefaultFontFamily = @"Imoji-Regular";
     _collectionView = [IMKeyboardCollectionView imojiCollectionViewWithSession:self.session];
     self.collectionView.clipsToBounds = YES;
     [self.collectionView setShowsHorizontalScrollIndicator:NO];
+    self.collectionView.loadingView.backgroundColor = self.backgroundColor;
 
     [self addSubview:self.collectionView];
 
@@ -136,6 +138,10 @@ NSString *const IMKeyboardViewDefaultFontFamily = @"Imoji-Regular";
         make.centerX.equalTo(self);
         make.right.equalTo(self.mas_right);
         make.left.equalTo(self.mas_left);
+    }];
+
+    [self.collectionView.loadingView mas_makeConstraints:^(MASConstraintMaker *make) {
+        make.edges.equalTo(self.collectionView);
     }];
 
     // toolbar


### PR DESCRIPTION
Fix keyboard loading view.