### PR TITLE
Issue #53: Fixes the crash related to force touch not being available…

### DIFF
--- a/Source/CollectionView/IMCollectionViewController.m
+++ b/Source/CollectionView/IMCollectionViewController.m
@@ -355,7 +355,8 @@ NSUInteger const IMCollectionViewControllerDefaultSearchDelayInMillis = 500;
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
 
-    if (self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
+    if ([self.traitCollection respondsToSelector:@selector(forceTouchCapability)] &&
+        self.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
         [self registerForPreviewingWithDelegate:self sourceView:self.collectionView];
     }
 }


### PR DESCRIPTION
… on iOS 8 devices by making sure traitCollection responds to forceTouchCapability before going through with registering the force touch delegate.