### PR TITLE
Handle crash where user taps a category and the category image has no…

### DIFF
--- a/Source/CollectionView/IMCollectionView.m
+++ b/Source/CollectionView/IMCollectionView.m
@@ -894,7 +894,7 @@ minimumInteritemSpacingForSectionAtIndex:(NSInteger)section {
     self.imojiOperation = operation =
             [self.session searchImojisWithTerm:searchTerm
                                         offset:offset
-                           contributingImojiId:imojiImage ? imojiImage.identifier : nil
+                           contributingImojiId:(imojiImage && ![imojiImage isEqual:[NSNull null]]) ? imojiImage.identifier : nil
                                numberOfResults:@(self.numberOfImojisToLoad)
                      resultSetResponseCallback:^(IMImojiResultSetMetadata *metadata, NSError *error) {
                          if (!operation.isCancelled) {


### PR DESCRIPTION
…t loaded yet, thereby passing an NSNull to contributingImojiId.